### PR TITLE
feat: add tiptap editing to cover title

### DIFF
--- a/app/create/_pages/CharactorAndPlotDesign.tsx
+++ b/app/create/_pages/CharactorAndPlotDesign.tsx
@@ -3,7 +3,6 @@ import CoverImageEditor from "@/app/create/_components/coverImageEditor/CoverIma
 import { CharacterForm } from "@/app/create/_components/CharacterForm";
 import { RelationshipForm } from "@/app/create/_components/RelationshipForm";
 import { CreateNovelForm } from "@/app/create/_schema/createNovelSchema";
-import { Input } from "@/components/ui/input";
 import { usePageContext } from "@/components/ui/pageContext";
 import { useToast } from "@/hooks/use-toast";
 import { useFormContext } from "react-hook-form";
@@ -92,18 +91,9 @@ export default function CharactorAndPlotDesign() {
     <div className="w-full p-4">
       <section className="mb-8 flex flex-col gap-4">
         <h2 className="text-xl ">소설 제목</h2>
-        <div className="relative">
-          <Input
-            type="text"
-            maxLength={20}
-            value={title}
-            {...register("title")}
-          />
-          <p className="text-destructive">{errors.title?.message}</p>
-        </div>
-        <div className="flex flex-col gap-6">
-          <CoverImageEditor />
-        </div>
+        <CoverImageEditor />
+        <input type="hidden" value={title} {...register("title")}/>
+        <p className="text-destructive">{errors.title?.message}</p>
       </section>
       <section className="mb-8">
         <h2 className="text-xl mb-4">줄거리</h2>


### PR DESCRIPTION
## Summary
- integrate Tiptap editor with `CoverImageEditor` so the novel title can be edited directly on the cover
- add controls for showing/hiding title and adjusting font size
- hide separate title input and keep it synced via hidden field

## Testing
- `pnpm run lint` *(fails: numerous existing lint errors)*
- `pnpm run test -- --runInBand` *(fails: no test script)*
- `pnpm run build` *(fails: lint errors prevent build)*