### PR TITLE
fix(create): 이미지 캡처 안정성 개선

### DIFF
--- a/app/create/_api/imageStorage.server.ts
+++ b/app/create/_api/imageStorage.server.ts
@@ -49,8 +49,10 @@ export async function saveImageFileToStorage(file: File) {
   const { error: uploadError } = await supabase.storage
     .from("novel-covers")
     .upload(filePath, file);
-
-  if (uploadError) throw new Error("이미지 업로드 중 오류가 발생했습니다.");
+  if (uploadError) {
+    console.error("[saveImageFileToStorage] upload error:", uploadError);
+    throw new Error("이미지 업로드 중 오류가 발생했습니다.");
+  }
 
   const {
     data: { publicUrl },

--- a/app/create/_pages/CharactorAndPlotDesign.tsx
+++ b/app/create/_pages/CharactorAndPlotDesign.tsx
@@ -76,7 +76,7 @@ export default function CharactorAndPlotDesign() {
     // await new Promise(resolve => setTimeout(resolve, 100)); 
 
     try {
-      
+      await document.fonts.ready;
       const imageDataUrl = await htmlToImage.toPng(coverImageRef.current, {
         width: 210,
         height: 270,

--- a/components/ui/pageContext.tsx
+++ b/components/ui/pageContext.tsx
@@ -3,7 +3,12 @@
 import { cva, VariantProps } from "class-variance-authority";
 import { ChevronLeft } from "lucide-react";
 import { useRouter } from "next/navigation";
-import React, { createContext, useContext, useState } from "react";
+import React, {
+  createContext,
+  useContext,
+  useState,
+  useEffect,
+} from "react";
 
 const prevButtonVariants = cva("absolute cursor-pointer z-50", {
   variants: {
@@ -49,8 +54,19 @@ export const PageProvider = ({
   const [currPage, setCurrPage] = useState(initialPage ?? 0);
   const [attemptedSubmit, setAttemptedSubmit] = useState(false);
   const [capturedImageFile, setCapturedImageFile] = useState<File | null>(null);
-  const [capturedImageDataUrl, setCapturedImageDataUrl] = useState<string | null>(null);
+  const [capturedImageDataUrl, setCapturedImageDataUrl] = useState<string | null>(
+    () => (typeof window !== "undefined" ? sessionStorage.getItem("capturedImageDataUrl") : null)
+  );
   const navigation = useRouter();
+
+  useEffect(() => {
+    if (typeof window === "undefined") return;
+    if (capturedImageDataUrl) {
+      sessionStorage.setItem("capturedImageDataUrl", capturedImageDataUrl);
+    } else {
+      sessionStorage.removeItem("capturedImageDataUrl");
+    }
+  }, [capturedImageDataUrl]);
 
   const prevButtonVisible = currPage > 0 && currPage <= maxPage && prevButton;
   const isLastStep = currPage === maxPage;


### PR DESCRIPTION
## Summary
- wait for fonts to load when capturing cover image
- persist captured image data in sessionStorage
- log upload errors for cover images

## Testing
- `pnpm run lint` *(fails: @typescript-eslint/no-explicit-any and others)*
- `pnpm run test -- --runInBand` *(fails: `Missing script: test`)*